### PR TITLE
Fixing warnings

### DIFF
--- a/Source/Request/Fixture/CMFixtureDownloadRequest.m
+++ b/Source/Request/Fixture/CMFixtureDownloadRequest.m
@@ -12,6 +12,12 @@
 #import "Cumulus.h"
 #import "CMFixtureHTTPResponse.h"
 
+// Allow access to the private timeout method in the CMRequest base class
+@interface CMRequest ()
+- (void) timeoutFired:(NSTimer *)timer;
+@end
+
+
 @interface CMFixtureDownloadRequest ()
 @property (nonatomic, readonly) NSURL *downloadedFileTempURL;
 @end

--- a/Source/Request/Fixture/CMFixtureRequest.m
+++ b/Source/Request/Fixture/CMFixtureRequest.m
@@ -12,6 +12,12 @@
 #import "Cumulus.h"
 #import "CMFixtureHTTPResponse.h"
 
+// Allow access to the private timeout method in the CMRequest base class
+@interface CMRequest ()
+- (void) timeoutFired:(NSTimer *)timer;
+@end
+
+
 @interface CMFixtureRequest ()
 @end
 


### PR DESCRIPTION
Fixed warnings by allowing Fixure objects to access a private timeout method.
